### PR TITLE
lock version of middleman-sprockets to 3.3.2 due to a bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gem 'middleman', '~>3.2.0'
 # Live-reloading plugin
 gem 'middleman-livereload', '~> 3.1.0'
 
+gem 'middleman-sprockets', '3.3.2'
+
 # For faster file watcher updates on Windows:
 gem 'wdm', '~> 0.1.0', :platforms => [:mswin, :mingw]
 


### PR DESCRIPTION
see: https://github.com/middleman/middleman/issues/1265
